### PR TITLE
Persist fifo counter at copy

### DIFF
--- a/src/fifo_map.hpp
+++ b/src/fifo_map.hpp
@@ -49,11 +49,11 @@ class fifo_map_compare
   public:
     /// constructor given a pointer to a key storage
     fifo_map_compare(
-        std::unordered_map<Key, std::size_t>* k,
+        std::unordered_map<Key, std::size_t>* keys,
         std::size_t timestamp = 1)
         :
-        timestamp(timestamp),
-        keys(k)
+        m_timestamp(timestamp),
+        m_keys(keys)
     {}
 
     /*!
@@ -63,16 +63,16 @@ class fifo_map_compare
     bool operator()(const Key& lhs, const Key& rhs) const
     {
         // look up timestamps for both keys
-        const auto timestamp_lhs = keys->find(lhs);
-        const auto timestamp_rhs = keys->find(rhs);
+        const auto timestamp_lhs = m_keys->find(lhs);
+        const auto timestamp_rhs = m_keys->find(rhs);
 
-        if (timestamp_lhs == keys->end())
+        if (timestamp_lhs == m_keys->end())
         {
             // timestamp for lhs not found - cannot be smaller than for rhs
             return false;
         }
 
-        if (timestamp_rhs == keys->end())
+        if (timestamp_rhs == m_keys->end())
         {
             // timestamp for rhs not found - timestamp for lhs is smaller
             return true;
@@ -84,20 +84,25 @@ class fifo_map_compare
 
     void add_key(const Key& key)
     {
-        keys->insert({key, timestamp++});
+        m_keys->insert({key, m_timestamp++});
     }
 
     void remove_key(const Key& key)
     {
-        keys->erase(key);
+        m_keys->erase(key);
     }
 
-    /// the next valid insertion timestamp
-    size_t timestamp = 1;
+    std::size_t timestamp() const
+    {
+        return m_timestamp;
+    }
 
   private:
+    /// the next valid insertion timestamp
+    std::size_t m_timestamp = 1;
+
     /// pointer to a mapping from keys to insertion timestamps
-    std::unordered_map<Key, std::size_t>* keys = nullptr;
+    std::unordered_map<Key, std::size_t>* m_keys = nullptr;
 };
 
 
@@ -133,7 +138,7 @@ template <
     fifo_map() : m_keys(), m_compare(&m_keys), m_map(m_compare) {}
 
     /// copy constructor
-    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.timestamp), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
+    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.timestamp()), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
 
     /// constructor for a range of elements
     template<class InputIterator>

--- a/src/fifo_map.hpp
+++ b/src/fifo_map.hpp
@@ -92,10 +92,15 @@ class fifo_map_compare
         m_keys->erase(key);
     }
 
-    std::size_t timestamp() const
-    {
-        return m_timestamp;
-    }
+  private:
+    /// helper to access m_timestamp from fifo_map copy ctor,
+    /// must have same number of template args as fifo_map
+    template <
+        class MapKey,
+        class MapT,
+        class MapCompare,
+        class MapAllocator
+        > friend class fifo_map;
 
   private:
     /// the next valid insertion timestamp
@@ -138,7 +143,7 @@ template <
     fifo_map() : m_keys(), m_compare(&m_keys), m_map(m_compare) {}
 
     /// copy constructor
-    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.timestamp()), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
+    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.m_timestamp), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
 
     /// constructor for a range of elements
     template<class InputIterator>

--- a/src/fifo_map.hpp
+++ b/src/fifo_map.hpp
@@ -48,7 +48,13 @@ class fifo_map_compare
 {
   public:
     /// constructor given a pointer to a key storage
-    fifo_map_compare(std::unordered_map<Key, std::size_t>* k) : keys(k) {}
+    fifo_map_compare(
+        std::unordered_map<Key, std::size_t>* k,
+        std::size_t timestamp = 1)
+        :
+        timestamp(timestamp),
+        keys(k)
+    {}
 
     /*!
     This function compares two keys with respect to the order in which they
@@ -86,11 +92,12 @@ class fifo_map_compare
         keys->erase(key);
     }
 
+    /// the next valid insertion timestamp
+    size_t timestamp = 1;
+
   private:
     /// pointer to a mapping from keys to insertion timestamps
     std::unordered_map<Key, std::size_t>* keys = nullptr;
-    /// the next valid insertion timestamp
-    size_t timestamp = 1;
 };
 
 
@@ -126,7 +133,7 @@ template <
     fifo_map() : m_keys(), m_compare(&m_keys), m_map(m_compare) {}
 
     /// copy constructor
-    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
+    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.timestamp), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
 
     /// constructor for a range of elements
     template<class InputIterator>


### PR DESCRIPTION
This PR fixes a bug when `nlohmann::basic_json<fifo_map>::merge_patch` is used after copying of a `nlohmann::basic_json<fifo_map>` object. 

Without copying of a timestamp counter, nested fields will be overwritten at their timestamp positions instead of names during `merge_patch`. Possibly other functionality will be broken too, but we have discovered problem particularly when were using `merge_patch`.

Minimal example to reproduce the problem with current master:
```cpp
#include <nlohmann/fifo_map.hpp>
#include <nlohmann/json.hpp>
#include <iostream>

template<class K, class V, class C, class A>
using fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>, A>;
using json = nlohmann::basic_json<fifo_map>;

static const json base_json =
{
    {"field1", {
        {"field11", {
            {"field111", {
                {"field1111", {
                    {"field11111", "value"}
                }}
            }}
        }},
        {"field21", {
            {"field211", {
                {"field2111", {
                    {"field21111", "value"}
                }}
            }}
        }}
    }}
};

int main(int argc, char *argv[])
{
    json schema = base_json; // timestamp is reset here during copying

    schema.merge_patch(
    {
        {"field1", {
            {"field13", {"value3"}},
            {"field14", "value4"}
        }}
    });

    std::cout << schema.dump(4) << std::endl;

    return 0;
}
```

Output with master:
```js
{
    "field1": {
        "field11": [
            "value3"
        ],
        "field21": "value4"
    }
}
```

Expected output:
```js
{
    "field1": {
        "field11": {
            "field111": {
                "field1111": {
                    "field11111": "value"
                }
            }
        },
        "field21": {
            "field211": {
                "field2111": {
                    "field21111": "value"
                }
            }
        },
        "field13": [
            "value3"
        ],
        "field14": "value4"
    }
}
```