### PR TITLE
Fix CXX_FLAGS: "-stdlib=libc++" is clang-specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,11 @@ if(MSVC)
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 else(MSVC)
     set(CMAKE_CXX_FLAGS
-        "-std=c++11 -stdlib=libc++"
+        "-std=c++11"
     )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    endif()
 endif(MSVC)
 
 include_directories(


### PR DESCRIPTION
Resolves #11 

Not sure why that flag was specified at all.
This change fixes build using gcc, without changing behaviour using clang.

Tested with clang10 + gcc9.3