### PR TITLE
Allowing this library to be used by package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@
 unit
 cm/*
 
+# build directories
+build*/
+
+# Visual Studio / Visual Studio Code
+.vs/
+.vscode/
+out/
+
+#QT-creator
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(GNUInstallDirs)
 
 add_library("nlohmann-fifo-map" INTERFACE)
 add_library("nlohmann-fifo-map::nlohmann-fifo-map" ALIAS "nlohmann-fifo-map")
-add_library("fifo_map::fifo_map" ALIAS "nlohmann-fifo-map") #Only for backward comptability
+add_library("fifo_map::fifo_map" ALIAS "nlohmann-fifo-map") #For backward comptability
 target_include_directories("nlohmann-fifo-map" INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -24,3 +24,41 @@ target_include_directories("unit" PRIVATE "test/thirdparty")
 target_link_libraries("unit" PRIVATE "nlohmann-fifo-map::nlohmann-fifo-map")
 
 
+
+install(TARGETS "nlohmann-fifo-map"
+    EXPORT "nlohmann-fifo-map-target"
+)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+if(NOT TARGET "uninstall")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+    )
+    add_custom_target("uninstall"
+        COMMAND "${CMAKE_COMMAND}" "-P" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    )
+endif()
+
+include(CMakePackageConfigHelpers)
+install(EXPORT "nlohmann-fifo-map-target"
+    DESTINATION "share/nlohmann-fifo-map"
+    NAMESPACE "nlohmann-fifo-map::"
+)
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/nlohmann-fifo-map-config.cmake"
+    INSTALL_DESTINATION "share/nlohmann-fifo-map"
+)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/nlohmann-fifo-map-config-version.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion
+)
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/nlohmann-fifo-map-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/nlohmann-fifo-map-config-version.cmake"
+    DESTINATION "share/nlohmann-fifo-map"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,39 +1,26 @@
-cmake_minimum_required(VERSION 2.8)
 
-project(fifo_map LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.16)
 
-add_executable(unit
-    src/fifo_map.hpp test/thirdparty/catch/catch.hpp test/unit.cpp
+project("nlohmann-fifo-map"
+    VERSION 1.0.0
+    LANGUAGES CXX
 )
 
-target_include_directories(unit PRIVATE "test" "src" "test/thirdparty")
+include(GNUInstallDirs)
 
-if(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "/EHsc"
-    )
-
-    STRING(REPLACE "/O2" "/Od" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
-
-    add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-else(MSVC)
-    set(CMAKE_CXX_FLAGS
-        "-std=c++11"
-    )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    endif()
-endif(MSVC)
-
-include_directories(
-    src test
+add_library("nlohmann-fifo-map" INTERFACE)
+add_library("nlohmann-fifo-map::nlohmann-fifo-map" ALIAS "nlohmann-fifo-map")
+add_library("fifo_map::fifo_map" ALIAS "nlohmann-fifo-map") #Only for backward comptability
+target_include_directories("nlohmann-fifo-map" INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-add_library(${PROJECT_NAME} INTERFACE)
-add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_include_directories(
-    ${PROJECT_NAME}
-    INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/>
+add_executable("unit"
+    "test/unit.cpp"
 )
+target_include_directories("unit" PRIVATE "test/thirdparty")
+target_link_libraries("unit" PRIVATE "nlohmann-fifo-map::nlohmann-fifo-map")
+
+

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ clean:
 FLAGS = -Wall -Wextra -pedantic -Weffc++ -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-declarations -Wmissing-include-dirs -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch -Wundef -Wno-unused -Wnon-virtual-dtor -Wreorder -Wdeprecated -Wfloat-equal
 
 # build unit tests
-unit: test/unit.cpp src/fifo_map.hpp test/thirdparty/catch/catch.hpp
-	$(CXX) -std=c++11 $(CXXFLAGS) $(FLAGS) $(CPPFLAGS) -I src -I test -I test/thirdparty $< $(LDFLAGS) -o $@
+unit: test/unit.cpp include/nlohmann/fifo_map.hpp test/thirdparty/catch/catch.hpp
+	$(CXX) -std=c++11 $(CXXFLAGS) $(FLAGS) $(CPPFLAGS) -I include -I test -I test/thirdparty $< $(LDFLAGS) -o $@
 
 check: unit
 	./unit "*"
@@ -27,4 +27,4 @@ pretty:
 	   --indent-col1-comments --pad-oper --pad-header --align-pointer=type \
 	   --align-reference=type --add-brackets --convert-tabs --close-templates \
 	   --lineend=linux --preserve-date --suffix=none \
-	   src/fifo_map.hpp test/unit.cpp
+	   include/nlohmann/fifo_map.hpp test/unit.cpp

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 C++ allows to defined associative containers such as `std::map`. The values are ordered according to their keys and an ordering relation. The `fifo_map` is an associative container which uses **the order in which keys were inserted to the container** as ordering relation.
 
-As it has the same interface than `std::map`, it can be used as drop-in replacement. The code is header-only (see file [src/fifo_map.hpp](https://github.com/nlohmann/fifo_map/blob/master/src/fifo_map.hpp)) and only relies on the STL.
+As it has the same interface than `std::map`, it can be used as drop-in replacement. The code is header-only (see file [include/nlohmann/fifo_map.hpp](https://raw.githubusercontent.com/nlohmann/fifo_map/c0ea4f41f0d32cf99a828a29ffe6382f774c1d0f/src/fifo_map.hpp)) and only relies on the STL.
 
 ## Complexity
 
@@ -25,12 +25,12 @@ Inserting a value (via `operator[]`, `insert`) and removing a value (`erase`) re
 ## Example
 
 ```cpp
-#include "src/fifo_map.hpp"
-
-// for convenience
-using nlohmann::fifo_map;
+#include <nlohmann/fifo_map.hpp>
 
 int main() {
+    // for convenience
+    using nlohmann::fifo_map;
+
     // create fifo_map with template arguments
     fifo_map<int, std::string> m;
 
@@ -63,7 +63,15 @@ int main() {
 }
 ```
 
-[Try this code online.](http://melpon.org/wandbox/permlink/l2f2Qxhq95qVKRgE)
+[Try this code online.](https://godbolt.org/z/9odbrzxen)
+
+
+## CMake
+This library provides CMake targets:
+```
+    find_package("nlohmann-fifo-map" REQUIRED)
+    target_link_libraries("main" PRIVATE "nlohmann-fifo-map::nlohmann-fifo-map")
+```
 
 ## License
 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,6 @@
+
+@PACKAGE_INIT@
+
+include("CMakeFindDependencyMacro")
+
+include("${CMAKE_CURRENT_LIST_DIR}/nlohmann-fifo-map-target.cmake")

--- a/cmake/uninstall.cmake.in
+++ b/cmake/uninstall.cmake.in
@@ -1,0 +1,24 @@
+
+#https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+    if(NOT "${rm_retval}" STREQUAL 0)
+        message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+    else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif()
+endforeach()

--- a/include/nlohmann/fifo_map.hpp
+++ b/include/nlohmann/fifo_map.hpp
@@ -143,7 +143,7 @@ template <
     fifo_map() : m_keys(), m_compare(&m_keys), m_map(m_compare) {}
 
     /// copy constructor
-    fifo_map(const fifo_map &f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.m_timestamp), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
+    fifo_map(const fifo_map& f) : m_keys(f.m_keys), m_compare(&m_keys, f.m_compare.m_timestamp), m_map(f.m_map.begin(), f.m_map.end(), m_compare) {}
 
     /// constructor for a range of elements
     template<class InputIterator>

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -13,7 +13,7 @@
 // allow accessing private members
 #define private public
 
-#include "fifo_map.hpp"
+#include <nlohmann/fifo_map.hpp>
 using nlohmann::fifo_map;
 
 #include <string>


### PR DESCRIPTION
This library lacks a cmake config file, which means it cannot be easily found with find_package.  
Given that package managers are becoming more used, I believe this should be addressed.

Currently, the vcpkg port uses hacky patches to enable it be to used:
https://github.com/microsoft/vcpkg/pull/8458
https://github.com/microsoft/vcpkg/issues/10809
https://github.com/microsoft/vcpkg/pull/10850

This pull request should allows this library to be easily ported to package managers, so such patches aren't needed.

The target name is nlohmann-fifo-map::nlohmann-fifo-map, as that's the one vcpkg users expect.
